### PR TITLE
Bash Strict mode

### DIFF
--- a/scripts/steam.sh
+++ b/scripts/steam.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+set -euo pipefail
+IFS=$'\n\t'
 
 # Allow us to debug what's happening in the script if necessary
 if [ "$STEAM_DEBUG" ]; then


### PR DESCRIPTION
Ensure variables are set and crash hard on failure. This is [bash strict mode](http://redsymbol.net/articles/unofficial-bash-strict-mode/) and helps to prevent incidents like https://github.com/ValveSoftware/steam-for-linux/issues/3671.